### PR TITLE
List All Contracts With Hierarchies

### DIFF
--- a/plugin/backends.py
+++ b/plugin/backends.py
@@ -4,7 +4,7 @@ from .exceptions import UnknownClassException
 
 
 backend_template = """
-Tables implemented:
+Contracts implemented:
 
 {contracts}
 """
@@ -16,9 +16,11 @@ def render_backend(data, match):
     if backend_data is None:
         raise UnknownClassException(f"Unknown class: {match}")
 
+    contracts = [
+        (c, c.lower().replace("/", "")) for c in sorted(backend_data["contracts"])
+    ]
     contracts = "\n".join(
-        f"* [`{c}`](contracts-reference.md#{c.lower()})"
-        for c in sorted(backend_data["tables"])
+        f"* [`{name}`](contracts-reference.md#{link})" for name, link in contracts
     )
 
     return backend_template.format(

--- a/plugin/contracts.py
+++ b/plugin/contracts.py
@@ -1,8 +1,3 @@
-from first import first
-
-from .exceptions import UnknownClassException
-
-
 contract_template = """
 ## {name}
 
@@ -14,24 +9,29 @@ contract_template = """
 
 
 {backend_support}
+
 """
 
 
-def render_contract(data, match):
-    # get contract details from data file
-    contract_data = first(data["contracts"], key=lambda c: c["dotted_path"] == match)
-    if contract_data is None:
-        raise UnknownClassException(f"Unknown class: {match}")
+def render_contracts(contracts_data):
+    outputs = []
 
-    docstring = "\n".join(contract_data["docstring"])
-    columns = "\n".join(
-        f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints']).capitalize()}. |"
-        for c in contract_data["columns"]
-    )
+    for contract in contracts_data:
+        hierarchy = [h.title() for h in contract["hierarchy"]]
+        name = "/".join([*hierarchy, contract["name"]])
+        docstring = "\n".join(contract["docstring"])
+        columns = "\n".join(
+            f"| {c['name']} | {c['description']} | {c['type']} | {', '.join(c['constraints']).capitalize()}. |"
+            for c in contract["columns"]
+        )
 
-    return contract_template.format(
-        name=contract_data["name"],
-        docstring=docstring,
-        columns=columns,
-        backend_support="",
-    ).strip()
+        output = contract_template.format(
+            name=name,
+            docstring=docstring,
+            columns=columns,
+            backend_support="",
+        )
+
+        outputs.append(output)
+
+    return "\n".join(outputs)

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -6,11 +6,10 @@ import re
 from mkdocs.plugins import BasePlugin
 
 from .backends import render_backend
-from .contracts import render_contract
+from .contracts import render_contracts
 
 
 backends_pat = re.compile(r"\n[\s]*!!!\sbackend:(.*)\n")
-contracts_pat = re.compile(r"\n[\s]*!!!\scontract:(.*)\n")
 
 DATA_FILE = os.environ.get("BACKEND_DOCS_FILE", "public_docs.json")
 
@@ -50,9 +49,9 @@ class DataBuilderPlugin(BasePlugin):
             backend = render_backend(data, match)
             markdown = markdown.replace(f"!!! backend:{match}", backend)
 
-        # find each matching `!!! dotted.path.Class` string in the markdown
-        for match in contracts_pat.findall(markdown):
-            contract = render_contract(data, match)
-            markdown = markdown.replace(f"!!! contract:{match}", contract)
+        # replace the contracts marker if it exists
+        if "!!! contracts" in markdown:
+            contracts = render_contracts(data["contracts"])
+            markdown = markdown.replace("!!! contracts", contracts)
 
         return markdown

--- a/tests/data.json
+++ b/tests/data.json
@@ -2,16 +2,17 @@
   "backends": [
     {
       "name": "DummyBackend1",
-      "tables": ["DummyClass", "DummyClass2"]
+      "contracts": ["Some/Path/DummyClass", "Some/Path/DummyClass2"]
     },
     {
       "name": "DummyBackend2",
-      "tables": ["DummyClass"]
+      "contracts": ["some/path/DummyClass"]
     }
   ],
   "contracts": [
     {
       "name": "DummyClass",
+      "hierarchy": ["some", "path"],
       "dotted_path": "dummy_module.DummyClass",
       "docstring": ["Dummy docstring"],
       "columns": [{
@@ -27,6 +28,7 @@
     },
     {
       "name": "DummyClass2",
+      "hierarchy": ["some", "path"],
       "dotted_path": "dummy_module2.DummyClass2",
       "docstring": ["Dummy docstring2.", "", "Second line."],
       "columns": [],

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -5,95 +5,12 @@ from plugin.exceptions import UnknownClassException
 from plugin.main import DataBuilderPlugin
 
 
-def test_multiple_paths_to_change(monkeypatch):
-    monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
-
-    markdown = """
-# this is a page title
-
-!!! contract:dummy_module.DummyClass
-
-!!! contract:dummy_module2.DummyClass2
-
-!!! backend:DummyBackend1
-
-!!! backend:DummyBackend2
-    """
-
-    output = DataBuilderPlugin().on_page_markdown(markdown, None, None, None)
-
-    expected = """
-# this is a page title
-
-## DummyClass
-
-Dummy docstring
-
-| Column name | Description | Type | Constraints |
-| ----------- | ----------- | ---- | ----------- |
-| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
-
-## DummyClass2
-
-Dummy docstring2.
-
-Second line.
-
-| Column name | Description | Type | Constraints |
-| ----------- | ----------- | ---- | ----------- |
-
-Tables implemented:
-
-* [`DummyClass`](contracts-reference.md#dummyclass)
-* [`DummyClass2`](contracts-reference.md#dummyclass2)
-
-Tables implemented:
-
-* [`DummyClass`](contracts-reference.md#dummyclass)
-    """
-
-    assert output == expected
-
-
-def test_no_paths_to_change(monkeypatch):
+def test_nothing_to_change(monkeypatch):
     monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
 
     output = DataBuilderPlugin().on_page_markdown("", None, None, None)
 
     assert output == ""
-
-
-def test_one_path_to_change(monkeypatch):
-    monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
-
-    markdown = """
-# this is a page title
-
-!!! contract:dummy_module.DummyClass
-
-!!! backend:DummyBackend1
-    """
-
-    output = DataBuilderPlugin().on_page_markdown(markdown, None, None, None)
-
-    expected = """
-# this is a page title
-
-## DummyClass
-
-Dummy docstring
-
-| Column name | Description | Type | Constraints |
-| ----------- | ----------- | ---- | ----------- |
-| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
-
-Tables implemented:
-
-* [`DummyClass`](contracts-reference.md#dummyclass)
-* [`DummyClass2`](contracts-reference.md#dummyclass2)
-    """
-
-    assert output == expected
 
 
 def test_no_data_file(monkeypatch):
@@ -103,15 +20,64 @@ def test_no_data_file(monkeypatch):
         DataBuilderPlugin().on_page_markdown("", None, None, None)
 
 
+def test_success(monkeypatch):
+    monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
+
+    markdown = """
+# this is a page title
+
+!!! contracts
+
+!!! backend:DummyBackend1
+    """
+
+    output = DataBuilderPlugin().on_page_markdown(markdown, None, None, None)
+
+    expected = """
+# this is a page title
+
+
+## Some/Path/DummyClass
+
+Dummy docstring
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
+
+
+
+
+
+
+## Some/Path/DummyClass2
+
+Dummy docstring2.
+
+Second line.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+
+
+
+
+
+
+
+Contracts implemented:
+
+* [`Some/Path/DummyClass`](contracts-reference.md#somepathdummyclass)
+* [`Some/Path/DummyClass2`](contracts-reference.md#somepathdummyclass2)
+    """
+
+    assert output == expected
+
+
 def test_unknown_class(monkeypatch):
     monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
 
     with pytest.raises(UnknownClassException):
         DataBuilderPlugin().on_page_markdown(
             "\n!!! backend:UnknownBackend\n", None, None, None
-        )
-
-    with pytest.raises(UnknownClassException):
-        DataBuilderPlugin().on_page_markdown(
-            "\n!!! contract:unknown_module.UnknownClass\n", None, None, None
         )


### PR DESCRIPTION
This renders the changes from opensafely-core/databuilder#400 and switches from rendering single contracts to all the contracts.  Contracts are sorted by their dotted path in the export function of databuilder, which means they're also sorted by hierachy (since the hierachy is also expressed in the module layout).  It's unclear if that ordering is the ideal one yet since we only have one contract full implemented so I'm leaving that decision for later.