### PR TITLE
fix: Support multiline series definitions in specs docs

### DIFF
--- a/plugin/specs.py
+++ b/plugin/specs.py
@@ -14,7 +14,10 @@ This example makes use of {intro} containing the following data:
 
 {input_tables}
 
-`{series}` returns the following patient series:
+```
+{series}
+```
+returns the following patient series:
 
 | patient | value |
 | - | - |

--- a/tests/data_with_multiline_series.json
+++ b/tests/data_with_multiline_series.json
@@ -1,0 +1,107 @@
+{
+  "backends": [
+    {
+      "name": "DummyBackend1",
+      "contracts": ["Some/Path/DummyClass", "Some/Path/DummyClass2"]
+    },
+    {
+      "name": "DummyBackend2",
+      "contracts": ["some/path/DummyClass"]
+    }
+  ],
+  "contracts": [
+    {
+      "name": "DummyClass",
+      "hierarchy": ["some", "path"],
+      "dotted_path": "dummy_module.DummyClass",
+      "docstring": ["Dummy docstring"],
+      "columns": [{
+        "name": "patient_id",
+        "description": "a column description",
+        "type": "PseudoPatientId",
+        "constraints": [
+          "Must have a value",
+          "Must be unique"
+        ]
+      }],
+      "backend_support": []
+    },
+    {
+      "name": "DummyClass2",
+      "hierarchy": ["some", "path"],
+      "dotted_path": "dummy_module2.DummyClass2",
+      "docstring": ["Dummy docstring2.", "", "Second line."],
+      "columns": [],
+      "backend_support": []
+    }
+  ],
+  "specs": [
+    {
+      "id": "1",
+      "title": "Logical case expressions",
+      "sections": [
+        {
+          "id": "1.1",
+          "title": "Logical case expressions",
+          "paragraphs": [
+            {
+              "id": "1.1.1",
+              "title": "Case with expression",
+              "tables": {
+                "p": [
+                  [
+                    "patient",
+                    "i1"
+                  ],
+                  [
+                    "1",
+                    "6"
+                  ],
+                  [
+                    "2",
+                    "7"
+                  ],
+                  [
+                    "3",
+                    "8"
+                  ],
+                  [
+                    "4",
+                    "9"
+                  ],
+                  [
+                    "5",
+                    ""
+                  ]
+                ]
+              },
+              "series": "case(\n    when(p.i1 < 8).then(p.i1),\n    when(p.i1 > 8).then(100),\n)",
+              "output": [
+                [
+                  "1",
+                  "6"
+                ],
+                [
+                  "2",
+                  "7"
+                ],
+                [
+                  "3",
+                  ""
+                ],
+                [
+                  "4",
+                  "100"
+                ],
+                [
+                  "5",
+                  ""
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -90,7 +90,10 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|203|F |
 | 3|302|F |
 
-`e.take(e.b1).i1.sum_for_patient()` returns the following patient series:
+```
+e.take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
 
 | patient | value |
 | - | - |
@@ -100,6 +103,99 @@ This example makes use of an event-level table named `e` containing the followin
 
     """
 
+    assert output == expected
+
+
+def test_success_with_multiline_series(monkeypatch):
+    monkeypatch.setattr(
+        plugin.main, "DATA_FILE", "tests/data_with_multiline_series.json"
+    )
+
+    markdown = """
+# this is a page title
+
+!!! contracts
+
+!!! backend:DummyBackend1
+
+!!! specs
+    """
+
+    output = DataBuilderPlugin().on_page_markdown(markdown, None, None, None)
+
+    expected = """
+# this is a page title
+
+
+## Some/Path/DummyClass
+
+Dummy docstring
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
+
+
+
+
+
+
+## Some/Path/DummyClass2
+
+Dummy docstring2.
+
+Second line.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+
+
+
+
+
+
+
+Contracts implemented:
+
+* [`Some/Path/DummyClass`](contracts-reference.md#somepathdummyclass)
+* [`Some/Path/DummyClass2`](contracts-reference.md#somepathdummyclass2)
+
+
+## 1 Logical case expressions
+
+
+### 1.1 Logical case expressions
+
+
+#### 1.1.1 Case with expression
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|i1 |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3|8 |
+| 4|9 |
+| 5| |
+
+```
+case(
+    when(p.i1 < 8).then(p.i1),
+    when(p.i1 > 8).then(100),
+)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|6 |
+| 2|7 |
+| 3| |
+| 4|100 |
+| 5| |
+
+    """
     assert output == expected
 
 
@@ -178,7 +274,10 @@ This example makes use of an event-level table named `e` containing the followin
 | 2|203|F |
 | 3|302|F |
 
-`e.take(e.b1).i1.sum_for_patient()` returns the following patient series:
+```
+e.take(e.b1).i1.sum_for_patient()
+```
+returns the following patient series:
 
 | patient | value |
 | - | - |


### PR DESCRIPTION
Goes with the [databuilder PR](https://github.com/opensafely-core/databuilder/pull/616) to extract multiline series definitions.
As the `series` code can be split over multiple lines, we now break before and after it, rather than inlining.