### PR TITLE
support codelists in spec paragraphs

### DIFF
--- a/plugin/specs.py
+++ b/plugin/specs.py
@@ -12,8 +12,7 @@ paragraph_template = """
 
 This example makes use of {intro} containing the following data:
 
-{input_tables}
-{codelists}
+{input_tables}{codelists}
 
 ```
 {series}
@@ -83,7 +82,7 @@ def render_specs(specs_data):
                 output_rows = "\n".join(build_rows(paragraph["output"]))
                 add_descriptive_text(paragraph)
                 codelists = ""
-                if paragraph["codelists"]:
+                if "codelists" in paragraph and paragraph["codelists"]:
                     for codelist in paragraph["codelists"]:
                         codelists += codelists_template.format(
                             system=codelist["system"],

--- a/plugin/specs.py
+++ b/plugin/specs.py
@@ -13,6 +13,7 @@ paragraph_template = """
 This example makes use of {intro} containing the following data:
 
 {input_tables}
+{codelists}
 
 ```
 {series}
@@ -22,6 +23,12 @@ returns the following patient series:
 | patient | value |
 | - | - |
 {output_rows}
+"""
+
+
+codelists_template = """
+
+and the following {system} codelist containing the following codes: {codes}
 """
 
 
@@ -75,6 +82,16 @@ def render_specs(specs_data):
                 input_tables = "\n\n".join(iter_input_tables(paragraph["tables"]))
                 output_rows = "\n".join(build_rows(paragraph["output"]))
                 add_descriptive_text(paragraph)
+                codelists = ""
+                if paragraph["codelists"]:
+                    for codelist in paragraph["codelists"]:
+                        codelists += codelists_template.format(
+                            system=codelist["system"],
+                            codes=", ".join(
+                                codelist["codes"],
+                            ),
+                        )
+                paragraph["codelists"] = codelists
 
                 output = paragraph_template.format(
                     **paragraph,

--- a/tests/data_with_codelist.json
+++ b/tests/data_with_codelist.json
@@ -1,0 +1,108 @@
+{
+    "backends": [
+      {
+        "name": "DummyBackend1",
+        "contracts": ["Some/Path/DummyClass", "Some/Path/DummyClass2"]
+      },
+      {
+        "name": "DummyBackend2",
+        "contracts": ["some/path/DummyClass"]
+      }
+    ],
+    "contracts": [
+      {
+        "name": "DummyClass",
+        "hierarchy": ["some", "path"],
+        "dotted_path": "dummy_module.DummyClass",
+        "docstring": ["Dummy docstring"],
+        "columns": [{
+          "name": "patient_id",
+          "description": "a column description",
+          "type": "PseudoPatientId",
+          "constraints": [
+            "Must have a value",
+            "Must be unique"
+          ]
+        }],
+        "backend_support": []
+      },
+      {
+        "name": "DummyClass2",
+        "hierarchy": ["some", "path"],
+        "dotted_path": "dummy_module2.DummyClass2",
+        "docstring": ["Dummy docstring2.", "", "Second line."],
+        "columns": [],
+        "backend_support": []
+      }
+    ],
+    "specs": [
+      {
+        "id": "1",
+        "title": "Operations on all series containing codes",
+        "sections": [
+          {
+            "id": "1.1",
+            "title": "Testing for containment using codes",
+            "paragraphs": [
+              {
+                "id": "1.1.1",
+                "title": "Is in",
+                "tables": {
+                    "p": [
+                      [
+                        "patient",
+                        "c1"
+                      ],
+                      [
+                        "1",
+                        "abc"
+                      ],
+                      [
+                        "2",
+                        "def"
+                      ],
+                      [
+                        "3",
+                        "ghi"
+                      ],
+                      [
+                        "4",
+                        ""
+                      ]
+                    ]
+                  },
+                  "series": "p.c1.is_in(codelist)",
+                  "output": [
+                    [
+                      "1",
+                      "T"
+                    ],
+                    [
+                      "2",
+                      "F"
+                    ],
+                    [
+                      "3",
+                      "T"
+                    ],
+                    [
+                      "4",
+                      ""
+                    ]
+                  ],
+                  "codelists": [
+                    {
+                      "system": "SNOMED CT",
+                      "codes": [
+                        "ghi",
+                        "abc"
+                      ]
+                    }
+                  ]
+                }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/tests/plugin/test_main.py
+++ b/tests/plugin/test_main.py
@@ -290,6 +290,96 @@ returns the following patient series:
     assert output == expected
 
 
+def test_success_with_codelist(monkeypatch):
+    monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data_with_codelist.json")
+
+    markdown = """
+# this is a page title
+
+!!! contracts
+
+!!! backend:DummyBackend1
+
+!!! specs
+    """
+
+    output = DataBuilderPlugin().on_page_markdown(markdown, None, None, None)
+
+    expected = """
+# this is a page title
+
+
+## Some/Path/DummyClass
+
+Dummy docstring
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+| patient_id | a column description | PseudoPatientId | Must have a value, must be unique. |
+
+
+
+
+
+
+## Some/Path/DummyClass2
+
+Dummy docstring2.
+
+Second line.
+
+| Column name | Description | Type | Constraints |
+| ----------- | ----------- | ---- | ----------- |
+
+
+
+
+
+
+
+Contracts implemented:
+
+* [`Some/Path/DummyClass`](contracts-reference.md#somepathdummyclass)
+* [`Some/Path/DummyClass2`](contracts-reference.md#somepathdummyclass2)
+
+
+## 1 Operations on all series containing codes
+
+
+### 1.1 Testing for containment using codes
+
+
+#### 1.1.1 Is in
+
+This example makes use of a patient-level table named `p` containing the following data:
+
+| patient|c1 |
+| - | - |
+| 1|abc |
+| 2|def |
+| 3|ghi |
+| 4| |
+
+and the following SNOMED CT codelist containing the following codes: ghi, abc
+
+
+```
+p.c1.is_in(codelist)
+```
+returns the following patient series:
+
+| patient | value |
+| - | - |
+| 1|T |
+| 2|F |
+| 3|T |
+| 4| |
+
+    """
+
+    assert output == expected
+
+
 def test_unknown_class(monkeypatch):
     monkeypatch.setattr(plugin.main, "DATA_FILE", "tests/data.json")
 


### PR DESCRIPTION
Part of the fix for https://github.com/opensafely/documentation/issues/778 alongside https://github.com/opensafely-core/databuilder/pull/908/