### PR TITLE
Change the default `DATA_FILE` path

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -12,7 +12,7 @@ from .specs import render_specs
 
 backends_pat = re.compile(r"\n[\s]*!!!\sbackend:(.*)\n")
 
-DATA_FILE = os.environ.get("BACKEND_DOCS_FILE", "public_docs.json")
+DATA_FILE = os.environ.get("BACKEND_DOCS_FILE", "docs/public_docs.json")
 
 
 class DataBuilderPlugin(BasePlugin):


### PR DESCRIPTION
In the separation of Data Builder documentation,
we now have `public_docs.json` in the `docs` directory too.